### PR TITLE
Fix issue #7 (MQTT reconnection)

### DIFF
--- a/src/H4P_AsyncMQTT.cpp
+++ b/src/H4P_AsyncMQTT.cpp
@@ -81,7 +81,12 @@ void H4P_AsyncMQTT::_greenLight(){
                 _downHooks();
                 _signal();
                 H4EVENT("MQTT DCX %d",reason);
-                if(autorestart && WiFi.status()==WL_CONNECTED) h4.every(H4MQ_RETRY,[this](){ connect(); },nullptr,H4P_TRID_MQRC,true);
+                if (autorestart)
+                    h4.once(H4MQ_RETRY, [this]() {
+                        if (WiFi.status() == WL_CONNECTED)
+                            h4.every(
+                                H4MQ_RETRY, [this]() { connect(); }, nullptr, H4P_TRID_MQRC, true);
+                    });
             });
         }
     });

--- a/src/H4P_WiFi.cpp
+++ b/src/H4P_WiFi.cpp
@@ -301,6 +301,7 @@ void H4P_WiFi::_wifiEvent(WiFiEvent_t event) {
     switch(event) {
         case SYSTEM_EVENT_STA_STOP:
         case SYSTEM_EVENT_STA_LOST_IP:
+        case SYSTEM_EVENT_STA_DISCONNECTED:
 			if(!(WiFi.getMode() & WIFI_AP)) h4.queueFunction([](){ h4wifi._lostIP(); }); // ? if?
 			//h4.queueFunction([](){ h4wifi._lostIP(); }); // ? if?
             break;

--- a/src/H4P_WiFi.cpp
+++ b/src/H4P_WiFi.cpp
@@ -255,7 +255,7 @@ void H4P_WiFi::_mcuStart(){ if(WiFi.getMode()==WIFI_OFF || WiFi.SSID()=="") _sta
 
 void H4P_WiFi::_stop(){
     _stopCore();
-    WiFi.disconnect(true,false);
+    WiFi.disconnect(false,false);
 }
 /* ESP32
 * WiFi Events

--- a/src/H4P_WiFi.cpp
+++ b/src/H4P_WiFi.cpp
@@ -251,7 +251,7 @@ void H4P_WiFi::_startSTA(){
     WiFi.begin(CSTR(_cb[ssidTag()]),CSTR(_cb[pskTag()]));
 }
 
-void H4P_WiFi::_mcuStart(){ WiFi.begin(); }
+void H4P_WiFi::_mcuStart(){ if(WiFi.getMode()==WIFI_OFF || WiFi.SSID()=="") _startSTA(); }
 
 void H4P_WiFi::_stop(){
     _stopCore();


### PR DESCRIPTION
Hi

Fix to #7  where this is the scenario :
= Router reboots
= MQTT senses disconnection, onDisconnect called : 
- MQTT [Destroys client](https://github.com/philbowles/PangolinMQTT/blob/master/src/PangolinMQTT.cpp#L88).
- H4P reschedules MQTT reconnect by this [code](https://github.com/philbowles/h4plugins/blob/dev/src/H4P_AsyncMQTT.cpp#L84) **Immediately** :
`if(autorestart && WiFi.status()==WL_CONNECTED) h4.every(H4MQ_RETRY,[this](){ connect(); },nullptr,H4P_TRID_MQRC,true);`
= after H4MQ_RETRY (10 seconds) , it calls `connect() ` :
- PANGO creates a "dead" client
= ESP8266 lostIP event.
= every H4MQ_RETRY, it calls `connect()` which ignores connection if there's a created instance of [PANGO::TCP](https://github.com/philbowles/PangolinMQTT/blob/master/src/PangolinMQTT.cpp#L286).



Here I've managed to (delay)  the re-connection So network event can occur before trying to reconnect to MQTT.
https://github.com/HamzaHajeir/h4plugins/commit/3e0b6236c7f0287ed969fa2b95b705edbdf188a0


This pull request contains another commit that solves another problem : 

The problem is : After MQTT is established again after a reboot, and after 30 seconds of unreachable MQTT server : onDisconnect is called, in which it doesn't activate the [reconnection lines](https://github.com/HamzaHajeir/h4plugins/commit/3e0b6236c7f0287ed969fa2b95b705edbdf188a0) because `_discoDone = true`.

That's because It doesn't pass through onConnect() callback function that sets `_discoDone` to `false`.

Removing _discoDone codes in H4P_AsyncMQTT solves the issue. And MQTT reconnects all the time without any issue.


Hope it helps

Hamza Hajeir