### PR TITLE
Fix ESP32 WiFi first connect at first flash

### DIFF
--- a/src/H4P_AsyncMQTT.cpp
+++ b/src/H4P_AsyncMQTT.cpp
@@ -81,7 +81,12 @@ void H4P_AsyncMQTT::_greenLight(){
                 _downHooks();
                 _signal();
                 H4EVENT("MQTT DCX %d",reason);
-                if(autorestart && WiFi.status()==WL_CONNECTED) h4.every(H4MQ_RETRY,[this](){ connect(); },nullptr,H4P_TRID_MQRC,true);
+                if (autorestart)
+                    h4.once(H4MQ_RETRY, [this]() {
+                        if (WiFi.status() == WL_CONNECTED)
+                            h4.every(
+                                H4MQ_RETRY, [this]() { connect(); }, nullptr, H4P_TRID_MQRC, true);
+                    });
             });
         }
     });

--- a/src/H4P_PersistentStorage.cpp
+++ b/src/H4P_PersistentStorage.cpp
@@ -37,7 +37,8 @@ void H4P_PersistentStorage::_hookIn() {
     vector<string> items=split(H4P_SerialCmd::read("/"+_pName),SEPARATOR);
     for(auto const& i:items){
         vector<string> nv=split(i,"=");
-        psRam[nv[0]]=nv[1];
+        if (nv.size() == 2)
+            psRam[nv[0]]=nv[1];
     }
 //    _hookFactory([this](){ clear(); });
     _factoryHook=[this](){ clear(); };

--- a/src/H4P_WiFi.cpp
+++ b/src/H4P_WiFi.cpp
@@ -301,6 +301,7 @@ void H4P_WiFi::_wifiEvent(WiFiEvent_t event) {
     switch(event) {
         case SYSTEM_EVENT_STA_STOP:
         case SYSTEM_EVENT_STA_LOST_IP:
+        case SYSTEM_EVENT_STA_DISCONNECTED:
 			if(!(WiFi.getMode() & WIFI_AP)) h4.queueFunction([](){ h4wifi._lostIP(); }); // ? if?
 			//h4.queueFunction([](){ h4wifi._lostIP(); }); // ? if?
             break;

--- a/src/H4P_WiFi.cpp
+++ b/src/H4P_WiFi.cpp
@@ -251,7 +251,7 @@ void H4P_WiFi::_startSTA(){
     WiFi.begin(CSTR(_cb[ssidTag()]),CSTR(_cb[pskTag()]));
 }
 
-void H4P_WiFi::_mcuStart(){ WiFi.begin(); }
+void H4P_WiFi::_mcuStart(){ if(WiFi.getMode()==WIFI_OFF || WiFi.SSID()=="") _startSTA(); }
 
 void H4P_WiFi::_stop(){
     _stopCore();


### PR DESCRIPTION
ESP32 Doesn't successfully connect to WiFi if it hasn't previously connected to wifi after.

How to replicate the stated error : 
- Erase ESP32 Flash memory
- Optional : Upload SPIFFS
- Upload any H4P_WiFi code giving credentials.

The fix mimic your solution At ESP8266 case.