### PR TITLE
fix h4/mqtt/change for brokers not using authentication

### DIFF
--- a/docs/h4mqtt.md
+++ b/docs/h4mqtt.md
@@ -36,7 +36,7 @@ It may be instantiated as any name the user chooses, prefix all API calls below 
 
 ## Commands Added
 
-* `h4/mqtt/change/w,x,y,z` (payload: w=newbroker, x=newport, y=newusername, z=newpassword)
+* `h4/mqtt/change/w,x[,y,z]` (payload: w=newbroker, x=newport, y=newusername, z=newpassword)
 * `h4/mqtt/report` // display basic details about the device
 
 # Events Listened for

--- a/src/H4P_AsyncMQTT.cpp
+++ b/src/H4P_AsyncMQTT.cpp
@@ -34,9 +34,10 @@ void __attribute__((weak)) onMQTTError(uint8_t e,int info){ SLOG("DEFAULT OE CAL
 uint32_t H4P_AsyncMQTT::_change(vector<string> vs){
     return _guard1(vs,[this](vector<string> vs){
         auto vg=split(H4PAYLOAD,",");
-        if(vg.size()!=4) return H4_CMD_PAYLOAD_FORMAT;
+        if(vg.size()!=2 && vg.size()!=4) return H4_CMD_PAYLOAD_FORMAT;
         if(!stringIsNumeric(vg[1])) return H4_CMD_NOT_NUMERIC;
-        change(vg[0],STOI(vg[1]),vg[2],vg[3]); // change this to a vs?
+        if(vg.size()==4) change(vg[0],STOI(vg[1]),vg[2],vg[3]); // change this to a vs?
+        else change(vg[0],STOI(vg[1]),"","");
         return H4_CMD_OK;
     });
 }


### PR DESCRIPTION
Improves the sanity check in `H4P_AsyncMQTT::_change` which caused the `h4/mqtt/change/` command to fail with error 7 (`H4_CMD_PAYLOAD_FORMAT`) when attempting to use empty strings as username/password: `h4/mqtt/change/192.168.1.24,1883,,`

The `split()` function from [H4Utils.cpp](https://github.com/philbowles/H4/blob/master/src/H4Utils.cpp#L65) discards empty tokens so regardless of the (correct) comma count in the command, the number of tokens passed to `_change` was 2.